### PR TITLE
Allow pick() to accept an array of 1 element

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verify-it",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Randomised test property/data generation for NodeJS",
   "keywords": [
     "testing",

--- a/src/generators/SelectionGenerators.js
+++ b/src/generators/SelectionGenerators.js
@@ -6,7 +6,7 @@ const SelectionGenerators = function (random) {
       throw new Error('The options to be picked from must be provided')
     } else if (!Array.isArray(values)) {
       throw new Error('The options to be picked from must be an array')
-    } else if (values.length <= 1) {
+    } else if (values.length < 1) {
       throw new Error('The options array must have at least one entry')
     }
 

--- a/test/GeneratorsSpec.js
+++ b/test/GeneratorsSpec.js
@@ -503,7 +503,7 @@ describe('Generators', () => {
     })
 
     it('should pick one of the entries from the values array', () => {
-      const length = TestData.integer(5, 10)
+      const length = TestData.integer(1, 10)
       const values = new Array(length).fill(1).map(TestData.string)
       Gen.pick(values)().should.be.oneOf(values)
     })


### PR DESCRIPTION
* The `pick()` generator throws an error if the supplied array contains less than 2 entries (`values.length <= 1`), but the corresponding error message states that the array must contain "at least one entry". This inconsistency is confusing.
* There are two options to fix this:
    * Change the condition so the function does accept arrays with just one entry
    * Change the error to state that the array must contain at least two entries
* I have opted for the first option, on the basis that the error message and associated unit test indicate the original intention was that `pick()` will work with array containing only one entry
* I am unsure if the version increment is correct - if someone is currently relying on `pick()` to throw an error if supplied an array with one entry, then this change will break that flow and so perhaps this is a breaking change? But that usage could be seen as being incorrect, and this is just a fix to correct the inconsistency between the logic and the error message